### PR TITLE
Added if condition on preexisting if statement due to pytorch update

### DIFF
--- a/flamo/processor/system.py
+++ b/flamo/processor/system.py
@@ -69,7 +69,7 @@ class Series(nn.Sequential):
                         (module._modules,), [*current_keys, *unpacked_modules.keys()]
                     )
                 )
-            elif isinstance(module, OrderedDict):
+            elif isinstance(module, OrderedDict) or isinstance(module, dict):
                 for k, v in module.items():
                     if isinstance(v, nn.Sequential):
                         # nested nn.Sequential
@@ -78,7 +78,7 @@ class Series(nn.Sequential):
                                 (v._modules,), [*current_keys, *unpacked_modules.keys()]
                             )
                         )
-                    elif isinstance(v, OrderedDict):
+                    elif isinstance(v, OrderedDict) or isinstance(module, dict):
                         # nested OrderedDict
                         unpacked_modules.update(
                             self.__unpack_modules(


### PR DESCRIPTION
One of the recent PyTorch updates has changes the returned value of nn.Sequential()._modules from an OrderedDict to a dict. Now the new if condition takes care of it.