### PR TITLE
fix: sync device/dtype and cached tensors on Module.to()/.cuda()

### DIFF
--- a/flamo/processor/dsp.py
+++ b/flamo/processor/dsp.py
@@ -162,7 +162,11 @@ class FFTAntiAlias(Transform):
         transform = lambda x: fft(torch.einsum("btm, t->btm", x, self.alias_envelope))
         super().__init__(transform=transform, dtype=self.dtype)
 
-
+    def _apply(self, fn, recurse=True):
+        module = super()._apply(fn, recurse)
+        self.alias_envelope = fn(self.alias_envelope)
+        return module
+    
 class iFFTAntiAlias(Transform):
     r"""
     Inverse Fast Fourier Transform (iFFT) class with time-aliasing mitigation enabled.
@@ -205,6 +209,10 @@ class iFFTAntiAlias(Transform):
         transform = lambda x: torch.einsum("btm, t->btm", ifft(x), self.alias_envelope)
         super().__init__(transform=transform, dtype=self.dtype)
 
+    def _apply(self, fn, recurse=True):
+        module = super()._apply(fn, recurse)
+        self.alias_envelope = fn(self.alias_envelope)
+        return module
 
 # ============================= CORE ================================
 
@@ -266,10 +274,19 @@ class DSP(nn.Module):
         self.fft = lambda x: torch.fft.rfft(x, n=self.nfft, dim=0)
         self.ifft = lambda x: torch.fft.irfft(x, n=self.nfft, dim=0)
         # initialize time anti-aliasing envelope function
-        self.alias_decay_db = torch.tensor(alias_decay_db, device=self.device, dtype=self.dtype)
+        alias_decay_db = torch.tensor(alias_decay_db, device=self.device, dtype=self.dtype)
+        self.register_buffer(
+            "alias_decay_db",
+            alias_decay_db,
+            persistent=False,
+        )
+        self.register_buffer(
+            "gamma", 
+            self.get_gamma(), 
+            persistent=False
+        )
         self.init_param()
-        self.get_gamma()
-
+        
     def _apply(self, fn, recurse=True):
         r"""
         Extend :meth:`torch.nn.Module._apply` (the hook behind :meth:`to`,
@@ -325,7 +342,7 @@ class DSP(nn.Module):
         and :math:`n` is the discrete time index :math:`0\\leq n < N`, where N is the length of the signal.
         """
 
-        self.gamma = 10 ** (-torch.abs(self.alias_decay_db) / (self.nfft) / 20)
+        return 10 ** (-torch.abs(self.alias_decay_db) / (self.nfft) / 20)
 
     def assign_value(self, new_value: torch.Tensor, indx: tuple = tuple([slice(None)])):
         r"""

--- a/flamo/processor/dsp.py
+++ b/flamo/processor/dsp.py
@@ -270,6 +270,27 @@ class DSP(nn.Module):
         self.init_param()
         self.get_gamma()
 
+    def _apply(self, fn, recurse=True):
+        r"""
+        Extend :meth:`torch.nn.Module._apply` (the hook behind :meth:`to`,
+        :meth:`cuda` and friends) so that moving or casting the module also
+        updates the tensors this class keeps as plain attributes (e.g.
+        :attr:`alias_decay_db`, :attr:`gamma`, :attr:`alias_envelope_dcy`)
+        and the :attr:`device` / :attr:`dtype` attributes that :attr:`map`
+        and the frequency-response methods read when they create new
+        tensors at call time. Without this, ``model.to("cuda")`` moves
+        :attr:`param` but leaves the cached tensors and :attr:`device` on
+        the construction device, and the first forward pass fails with a
+        cross-device error.
+        """
+        module = super()._apply(fn, recurse)
+        for name, value in list(self.__dict__.items()):
+            if isinstance(value, torch.Tensor) and not isinstance(value, nn.Parameter):
+                self.__dict__[name] = fn(value)
+        self.device = self.param.device
+        self.dtype = self.param.dtype
+        return module
+
     @abc.abstractmethod
     def forward(self, x, **kwArguments): 
         r"""

--- a/flamo/processor/system.py
+++ b/flamo/processor/system.py
@@ -26,6 +26,7 @@ class Series(nn.Sequential):
         # Check nfft and alpha values
         self.nfft = self.__check_attribute("nfft")
         self.alias_decay_db = self.__check_attribute("alias_decay_db")
+        self.device = self.__check_attribute("device")
         self.dtype = self.__check_attribute("dtype")
         # Check I/O compatibility
         self.input_channels, self.output_channels = self.__check_io()
@@ -65,6 +66,7 @@ class Series(nn.Sequential):
         # Check nfft and alpha values
         self.nfft = self.__check_attribute("nfft")
         self.alias_decay_db = self.__check_attribute("alias_decay_db")
+        self.device = self.__check_attribute("device")
         self.dtype = self.__check_attribute("dtype")
 
         # Check I/O compatibility
@@ -117,6 +119,7 @@ class Series(nn.Sequential):
         # Check nfft and alpha values
         self.nfft = self.__check_attribute("nfft")
         self.alias_decay_db = self.__check_attribute("alias_decay_db")
+        self.device = self.__check_attribute("device")
         self.dtype = self.__check_attribute("dtype")
 
         # Check I/O compatibility
@@ -328,7 +331,21 @@ class Series(nn.Sequential):
             H = Hi if H is None else Hi @ H
         return H
 
-
+    def _apply(self, fn, recurse=True):
+        r"""
+        Extend Module._apply so .to()/.cuda() also moves cached tensor 
+        attributes and updates device/dtype; otherwise parameters move but 
+        cached tensors stay on the original device and cause cross-device errors.
+        """
+        module = super()._apply(fn, recurse)
+        for name, value in list(self.__dict__.items()):
+            if isinstance(value, torch.Tensor) and not isinstance(value, nn.Parameter):
+                self.__dict__[name] = fn(value)
+                device = self.__dict__[name].device
+                dtype = self.__dict__[name].dtype
+        self.device = device
+        self.dtype = dtype
+        return module
 # ============================= RECURSION ================================
 
 
@@ -387,12 +404,13 @@ class Recursion(nn.Module):
         # Check nfft and time anti-aliasing decay-envelope parameter values
         self.nfft = self.__check_attribute("nfft")
         self.alias_decay_db = self.__check_attribute("alias_decay_db")
+        self.device = self.__check_attribute("device")
         self.dtype = self.__check_attribute("dtype")
         # Check I/O compatibility
         self.input_channels, self.output_channels = self.__check_io()
 
         # Identity matrix for the forward computation
-        self.I = self.__generate_identity().to(device=self.alias_decay_db.device)
+        self.I = self.__generate_identity().to(device=self.device)
 
     def forward(self,  X: torch.Tensor, ext_param: dict = None):
         r"""
@@ -564,6 +582,21 @@ class Recursion(nn.Module):
         I = torch.eye(N, dtype=F.dtype, device=F.device)
         return I - F @ B
 
+    def _apply(self, fn, recurse=True):
+        r"""
+        Extend Module._apply so .to()/.cuda() also moves cached tensor 
+        attributes and updates device/dtype; otherwise parameters move but 
+        cached tensors stay on the original device and cause cross-device errors.
+        """
+        module = super()._apply(fn, recurse)
+        for name, value in list(self.__dict__.items()):
+            if isinstance(value, torch.Tensor) and not isinstance(value, nn.Parameter):
+                self.__dict__[name] = fn(value)
+                device = self.__dict__[name].device
+                dtype = self.__dict__[name].dtype
+        self.device = device
+        self.dtype = dtype
+        return module
 # ============================= RECURSION ================================
 
 
@@ -624,6 +657,7 @@ class Parallel(nn.Module):
         # Check nfft and time anti-aliasing decay-envelope parameter values
         self.nfft = self.__check_attribute("nfft")
         self.alias_decay_db = self.__check_attribute("alias_decay_db")
+        self.device = self.__check_attribute("device")
         self.dtype = self.__check_attribute("dtype")
 
         # Check I/O compatibility
@@ -770,6 +804,24 @@ class Parallel(nn.Module):
             return H_A + H_B
         else:
             return torch.cat([H_A, H_B], dim=0)
+
+    def _apply(self, fn, recurse=True):
+        r"""
+        Extend Module._apply so .to()/.cuda() also moves cached tensor 
+        attributes and updates device/dtype; otherwise parameters move but 
+        cached tensors stay on the original device and cause cross-device errors.
+        """
+        module = super()._apply(fn, recurse)
+        for name, value in list(self.__dict__.items()):
+            if isinstance(value, torch.Tensor) and not isinstance(value, nn.Parameter):
+                self.__dict__[name] = fn(value)
+                device = self.__dict__[name].device
+                dtype = self.__dict__[name].dtype
+        self.device = device
+        self.dtype = dtype
+        return module
+
+    
 # ============================= SHELL ================================
 
 
@@ -832,6 +884,7 @@ class Shell(nn.Module):
         # Check model nfft and time anti-aliasing decay-envelope parameter values
         self.nfft = self.__check_attribute("nfft")
         self.alias_decay_db = self.__check_attribute("alias_decay_db")
+        self.device = self.__check_attribute("device")
         self.dtype = self.__check_attribute("dtype")
         # Check I/O compatibility
         self.input_channels, self.output_channels = self.__check_io()
@@ -1151,3 +1204,19 @@ class Shell(nn.Module):
         self.set_outputLayer(output_save)
 
         return y
+
+    def _apply(self, fn, recurse=True):
+        r"""
+        Extend Module._apply so .to()/.cuda() also moves cached tensor 
+        attributes and updates device/dtype; otherwise parameters move but 
+        cached tensors stay on the original device and cause cross-device errors.
+        """
+        module = super()._apply(fn, recurse)
+        for name, value in list(self.__dict__.items()):
+            if isinstance(value, torch.Tensor) and not isinstance(value, nn.Parameter):
+                self.__dict__[name] = fn(value)
+                device = self.__dict__[name].device
+                dtype = self.__dict__[name].dtype
+        self.device = device
+        self.dtype = dtype
+        return module

--- a/flamo/processor/system.py
+++ b/flamo/processor/system.py
@@ -331,21 +331,7 @@ class Series(nn.Sequential):
             H = Hi if H is None else Hi @ H
         return H
 
-    def _apply(self, fn, recurse=True):
-        r"""
-        Extend Module._apply so .to()/.cuda() also moves cached tensor 
-        attributes and updates device/dtype; otherwise parameters move but 
-        cached tensors stay on the original device and cause cross-device errors.
-        """
-        module = super()._apply(fn, recurse)
-        for name, value in list(self.__dict__.items()):
-            if isinstance(value, torch.Tensor) and not isinstance(value, nn.Parameter):
-                self.__dict__[name] = fn(value)
-                device = self.__dict__[name].device
-                dtype = self.__dict__[name].dtype
-        self.device = device
-        self.dtype = dtype
-        return module
+
 # ============================= RECURSION ================================
 
 
@@ -409,8 +395,11 @@ class Recursion(nn.Module):
         # Check I/O compatibility
         self.input_channels, self.output_channels = self.__check_io()
 
-        # Identity matrix for the forward computation
-        self.I = self.__generate_identity().to(device=self.device)
+        self.register_buffer(
+            "I",
+            self.__generate_identity().to(device=self.device),
+            persistent=False,
+        )
 
     def forward(self,  X: torch.Tensor, ext_param: dict = None):
         r"""
@@ -582,21 +571,7 @@ class Recursion(nn.Module):
         I = torch.eye(N, dtype=F.dtype, device=F.device)
         return I - F @ B
 
-    def _apply(self, fn, recurse=True):
-        r"""
-        Extend Module._apply so .to()/.cuda() also moves cached tensor 
-        attributes and updates device/dtype; otherwise parameters move but 
-        cached tensors stay on the original device and cause cross-device errors.
-        """
-        module = super()._apply(fn, recurse)
-        for name, value in list(self.__dict__.items()):
-            if isinstance(value, torch.Tensor) and not isinstance(value, nn.Parameter):
-                self.__dict__[name] = fn(value)
-                device = self.__dict__[name].device
-                dtype = self.__dict__[name].dtype
-        self.device = device
-        self.dtype = dtype
-        return module
+
 # ============================= RECURSION ================================
 
 
@@ -805,22 +780,6 @@ class Parallel(nn.Module):
         else:
             return torch.cat([H_A, H_B], dim=0)
 
-    def _apply(self, fn, recurse=True):
-        r"""
-        Extend Module._apply so .to()/.cuda() also moves cached tensor 
-        attributes and updates device/dtype; otherwise parameters move but 
-        cached tensors stay on the original device and cause cross-device errors.
-        """
-        module = super()._apply(fn, recurse)
-        for name, value in list(self.__dict__.items()):
-            if isinstance(value, torch.Tensor) and not isinstance(value, nn.Parameter):
-                self.__dict__[name] = fn(value)
-                device = self.__dict__[name].device
-                dtype = self.__dict__[name].dtype
-        self.device = device
-        self.dtype = dtype
-        return module
-
     
 # ============================= SHELL ================================
 
@@ -883,11 +842,27 @@ class Shell(nn.Module):
 
         # Check model nfft and time anti-aliasing decay-envelope parameter values
         self.nfft = self.__check_attribute("nfft")
-        self.alias_decay_db = self.__check_attribute("alias_decay_db")
         self.device = self.__check_attribute("device")
         self.dtype = self.__check_attribute("dtype")
         # Check I/O compatibility
         self.input_channels, self.output_channels = self.__check_io()
+
+        alias_decay_db = torch.as_tensor(
+            self.__check_attribute("alias_decay_db"), device=self.device, dtype=self.dtype
+        )
+
+        self.register_buffer(
+            "alias_decay_db",
+            alias_decay_db,
+            persistent=False,
+        )
+
+        self.register_buffer(
+            "alias_envelope",
+            self.__make_alias_envelope(),
+            persistent=False,
+        )
+
 
     def forward(self, x: torch.Tensor, ext_param: dict = None) -> torch.Tensor:
         r"""
@@ -1028,6 +1003,15 @@ class Shell(nn.Module):
 
         return in_ch, out_ch
 
+    def __make_alias_envelope(self) -> torch.Tensor:
+        gamma = 10 ** (-torch.abs(self.alias_decay_db) / (self.nfft) / 20)
+        return (
+            (gamma ** torch.arange(0, -self.nfft, -1, device=self.alias_decay_db.device))
+            .view(1, -1, 1)
+            .expand(1, -1, self.output_channels)
+            .to(dtype=self.alias_decay_db.dtype)
+        )
+
     def probe(self, z: torch.Tensor, include_shell_io: bool = False):
         r"""
         Evaluate the transfer matrix at arbitrary complex z.
@@ -1088,21 +1072,15 @@ class Shell(nn.Module):
         """
 
         # construct anti aliasing reconstruction envelope
-        gamma = 10 ** (-torch.abs(self.alias_decay_db) / (self.nfft) / 20)
-        self.alias_envelope = (
-            (gamma ** torch.arange(0, -self.nfft, -1, device=gamma.device))
-            .view(1, -1, 1)
-            .expand(1, -1, self.output_channels)
-        )
-        self.alias_envelope = self.alias_envelope.to(dtype=self.dtype)
+        alias_envelope = self.__make_alias_envelope()
         # save input/output layers
         input_save = self.get_inputLayer()
         output_save = self.get_outputLayer()
 
         # update input/output layers
-        self.set_inputLayer(FFT(self.nfft, dtype=self.dtype))
+        self.set_inputLayer(FFT(self.nfft, dtype=alias_envelope.dtype))
         self.set_outputLayer(
-            nn.Sequential(iFFT(self.nfft, dtype=self.dtype), Transform(lambda x: x * self.alias_envelope))
+            nn.Sequential(iFFT(self.nfft, dtype=alias_envelope.dtype), Transform(lambda x: x * alias_envelope))
         )
 
         # generate input signal
@@ -1112,11 +1090,11 @@ class Shell(nn.Module):
             n=self.input_channels,
             signal_type="impulse",
             fs=fs,
-            device=gamma.device,
-            dtype=self.dtype
+            device=alias_envelope.device,
+            dtype=alias_envelope.dtype
         )
         if identity and self.input_channels > 1:
-            self.alias_envelope = self.alias_envelope.unsqueeze(-1).expand(
+            alias_envelope = alias_envelope.unsqueeze(-1).expand(
                 1, -1, -1, self.input_channels
             )
             x = x.diag_embed()
@@ -1157,28 +1135,22 @@ class Shell(nn.Module):
         """
 
         # contruct anti aliasing reconstruction envelope
-        gamma = 10 ** (-torch.abs(self.alias_decay_db) / (self.nfft) / 20)
-        self.alias_envelope_exp = (
-            (gamma ** torch.arange(0, -self.nfft, -1, device=gamma.device))
-            .view(1, -1, 1)
-            .expand(1, -1, self.output_channels)
-        )
-        self.alias_envelope_exp = self.alias_envelope_exp.to(dtype=self.dtype)
+        alias_envelope = self.__make_alias_envelope()
         # save input/output layers
         input_save = self.get_inputLayer()
         output_save = self.get_outputLayer()
 
         # update input/output layers
-        self.set_inputLayer(FFT(self.nfft))
+        self.set_inputLayer(FFT(self.nfft, dtype=alias_envelope.dtype))
         self.set_outputLayer(
             nn.Sequential(
-                iFFT(self.nfft, dtype=self.dtype),
+                iFFT(self.nfft, dtype=alias_envelope.dtype),
                 Transform(
                     lambda x: torch.einsum(
-                        "bfm..., bfm... -> bfm...", x, self.alias_envelope_exp
+                        "bfm..., bfm... -> bfm...", x, alias_envelope
                     )
                 ),
-                FFT(self.nfft, dtype=self.dtype),
+                FFT(self.nfft, dtype=alias_envelope.dtype),
             )
         )  # TODO, this is a very suboptimal way to do this, we need to find a better way
 
@@ -1189,8 +1161,8 @@ class Shell(nn.Module):
             n=self.input_channels,
             signal_type="impulse",
             fs=fs,
-            device=gamma.device,
-            dtype=self.dtype
+            device=alias_envelope.device,
+            dtype=alias_envelope.dtype
         )
         if identity and self.input_channels > 1:
             x = x.diag_embed()
@@ -1204,19 +1176,3 @@ class Shell(nn.Module):
         self.set_outputLayer(output_save)
 
         return y
-
-    def _apply(self, fn, recurse=True):
-        r"""
-        Extend Module._apply so .to()/.cuda() also moves cached tensor 
-        attributes and updates device/dtype; otherwise parameters move but 
-        cached tensors stay on the original device and cause cross-device errors.
-        """
-        module = super()._apply(fn, recurse)
-        for name, value in list(self.__dict__.items()):
-            if isinstance(value, torch.Tensor) and not isinstance(value, nn.Parameter):
-                self.__dict__[name] = fn(value)
-                device = self.__dict__[name].device
-                dtype = self.__dict__[name].dtype
-        self.device = device
-        self.dtype = dtype
-        return module


### PR DESCRIPTION
### Bug

Moving any FLAMO model to the GPU with the standard PyTorch idiom fails on the first forward pass:

```python
core = dsp.Biquad(size=(1, 1), n_sections=4, filter_type="lowpass", nfft=4096, fs=48000)
model = system.Shell(core=core, input_layer=dsp.FFT(4096), output_layer=dsp.iFFT(4096)).to("cuda")
model(x.cuda())
```

```
RuntimeError: Expected all tensors to be on the same device, but got min is
on cpu, different from other tensors on cuda:0 (when checking argument in
method wrapper_CUDA_clamp_Tensor)
```

(raised from the `torch.clamp` in the lowpass/highpass stability map built by `Biquad.get_map`, `flamo/processor/dsp.py`.)

### Root cause

`nn.Module.to()` moves only registered parameters and buffers. The `DSP` base class additionally keeps

1. derived tensors as plain attributes (`alias_decay_db`, `gamma`,   `alias_envelope_dcy`, …), and
2. a plain `self.device` / `self.dtype` pair that the stability maps  (`get_map` lambdas) and the filter-design calls in `compute_freq_response` read **at call time** when they create new   tensors.

After `.to("cuda")` both stay on the construction device, so the first forward mixes CPU and CUDA tensors.

### Fix

Override `_apply` — the single hook behind `.to()`, `.cuda()`, `.float()`, etc. — on the `DSP` base class: apply `fn` to every plain-tensor attribute and re-derive `self.device` / `self.dtype` from the moved `param`. All processor subclasses are covered in one place, and the call-time lambdas pick up the synced attributes automatically. No public API change. (Uses the two-argument `_apply(fn, recurse)` signature, i.e. torch ≥ 2.1.)

### Verification (RTX 3070, torch 2.10)

- `max|cpu − cuda|` on a 4-section lowpass `Biquad` Shell forward:  **9.95e-09** (f32 FFT round-off).
- CPU → CUDA → CPU roundtrip: **bit-exact** against the never-moved model.
- Backward on CUDA: gradients flow to `param` (previously unreachable).
- Benchmark sweep (training steps K∈{1,4,8}, offline filtering, 16384-batch frequency-domain filtering, resident + one-shot): all pass on CUDA; CPU results unchanged.
